### PR TITLE
Fix: TypeError in add function by converting inputs to int

### DIFF
--- a/PatchIQ_AI_2/PatchIQAI_App/Agent Test Code/buggy_code.py
+++ b/PatchIQ_AI_2/PatchIQAI_App/Agent Test Code/buggy_code.py
@@ -1,0 +1,5 @@
+def add(num1, num2):
+    result = int(num1) + int(num2)
+    return result
+
+print(add("5", 10))


### PR DESCRIPTION
This PR fixes the TypeError: can only concatenate str (not "int") to str in the add function. The fix involves explicitly converting both 'num1' and 'num2' to integers using `int()` before performing the addition.