### PR TITLE
Fix: The 'TypeError: can only concatenate str (not "int") to str' occurs because 'num1' is retrieved as a string ('5') and 'num2' as an integer (10). The '+' operator attempts string concatenation due to 'num1' being a string, but fails when 'num2' is not also a string, leading to a type mismatch.

### DIFF
--- a/PatchIQAI_App/Agent Test Code/buggy_code.py
+++ b/PatchIQAI_App/Agent Test Code/buggy_code.py
@@ -2,7 +2,7 @@ def add(data):
     num1 = data.get('num1')
     num2 = data.get('num2')
     
-    result = num1 + num2
+    result = int(num1) + int(num2)
   
     return {
         'result': result,


### PR DESCRIPTION
Details: Modify line 6 from `result = num1 + num2` to `result = int(num1) + int(num2)`. This change explicitly converts both `num1` and `num2` to integers before performing the addition, ensuring numerical summation and preventing the type error caused by attempting to concatenate a string with an integer.