### PR TITLE
Fix: The `add_book_to_cart` function attempts to access the 'stock' key of a book dictionary without verifying its existence. When a book (like the digital e-book with ID 777) does not have a 'stock' key, this results in a KeyError.

### DIFF
--- a/PatchIQAI_App/Agent Test Code/buggy_bookstore.py
+++ b/PatchIQAI_App/Agent Test Code/buggy_bookstore.py
@@ -113,14 +113,20 @@ def add_book_to_cart():
             break
 
     if found_book:
-        # --- THE CRASH WILL HAPPEN ON THE NEXT LINE ---
-        # The code does not check if the 'stock' key exists before using it.
-        if found_book["stock"] > 0: 
+        # --- FIX START ---
+        # Check if the book has a 'stock' key and if it's > 0 (for physical books)
+        if 'stock' in found_book and found_book["stock"] > 0:
             SHOPPING_CART.append(found_book["id"])
-            found_book["stock"] -= 1 # This would also fail for the same reason
+            found_book["stock"] -= 1 # Decrement stock only for physical books
             print(f"\n[SUCCESS] '{found_book['title']}' has been added to your cart.")
+        # Check if the book is digital (always available)
+        elif 'format' in found_book and found_book['format'] == 'digital':
+            SHOPPING_CART.append(found_book["id"])
+            print(f"\n[SUCCESS] '{found_book['title']}' (Digital) has been added to your cart.")
         else:
-            print(f"\n[SORRY] '{found_book['title']}' is currently out of stock.")
+            # Otherwise, it's out of stock or unavailable (e.g., stock is 0, or no stock/format key)
+            print(f"\n[SORRY] '{found_book['title']}' is currently out of stock or unavailable.")
+        # --- FIX END ---
     else:
         print(f"\n[!] Error: No book found with ID {book_id_to_add}.")
 


### PR DESCRIPTION
Details: Modify the `add_book_to_cart` function to first check if the 'stock' key exists and its value is greater than 0 for physical books. For digital books (identified by a 'format' key with value 'digital'), they are always considered available and added to the cart without stock checks. Otherwise, the book is considered out of stock.