### PR TITLE
Fix: The `add_book_to_cart` function attempts to access the 'stock' key of a book dictionary (`found_book["stock"]`) without first verifying if the key exists. This causes a `KeyError` when a book like 'The Art of Python (Digital E-book)' (ID 777), which does not have a 'stock' key but instead a 'format' key, is selected.

### DIFF
--- a/PatchIQAI_App/Agent Test Code/buggy_bookstore.py
+++ b/PatchIQAI_App/Agent Test Code/buggy_bookstore.py
@@ -103,12 +103,18 @@ def add_book_to_cart():
             break
 
     if found_book:
-        if found_book["stock"] > 0: 
+        if 'stock' in found_book: # Check if 'stock' key exists
+            if found_book["stock"] > 0: 
+                SHOPPING_CART.append(found_book["id"])
+                found_book["stock"] -= 1
+                print(f"\n[SUCCESS] '{found_book['title']}' has been added to your cart.")
+            else:
+                print(f"\n[SORRY] '{found_book['title']}' is currently out of stock.")
+        elif 'format' in found_book and found_book['format'] == 'digital': # Check if it's a digital book
             SHOPPING_CART.append(found_book["id"])
-            found_book["stock"] -= 1
-            print(f"\n[SUCCESS] '{found_book['title']}' has been added to your cart.")
+            print(f"\n[SUCCESS] '{found_book['title']}' (Digital) has been added to your cart.")
         else:
-            print(f"\n[SORRY] '{found_book['title']}' is currently out of stock.")
+            print(f"\n[INFO] '{found_book['title']}' cannot be added to cart due to unknown availability status.")
     else:
         print(f"\n[!] Error: No book found with ID {book_id_to_add}.")
 


### PR DESCRIPTION
Details: Modify the `add_book_to_cart` function to first check if the 'stock' key exists in the `found_book` dictionary. If it exists, proceed with the stock check and decrement. If it does not exist, check if the book is a 'digital' format, and if so, add it to the cart without stock considerations. Add a fallback for unknown book types.